### PR TITLE
Hide the primary index from SQLAlchemy and its consumers

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -142,6 +142,12 @@ class CockroachDBDialect(PGDialect_psycopg2):
         res = []
         # Map over uniques because it preserves order.
         for name in uniques:
+            # In order to mimic postgresql behaviour, we hide the primary
+            # index from SQLAlchemy. One of the side effects of exposing it
+            # is when comparing the database state against models, for
+            # example when Alembic autogenerates migrations.
+            if name == "primary":
+                continue
             res.append(dict(name=name, column_names=columns[name], unique=uniques[name]))
         return res
 


### PR DESCRIPTION
This caused a problem with applications that used reflection to compare
the models against the database state, for example, Alembic. Alembic
attempts to autogenerate migrations that forward the database to match
models. What this means is that the implicit relations such as the
primary index will then be scheduled to drop.

---

I imagine we may also need to skip the unique constraint. Going to test this later today and also look into enabling/fixing the SQLAlchemy tests.

