### PR TITLE
Allow column type changes via alembic

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.util import warn
 import sqlalchemy.sql as sql
 
@@ -451,6 +452,9 @@ else:
         __dialect__ = 'cockroachdb'
         transactional_ddl = False
 
+    @compiles(alembic.ddl.postgresql.PostgresqlColumnType, 'cockroachdb')
+    def visit_column_type(*args, **kwargs):
+        return alembic.ddl.postgresql.visit_column_type(*args, **kwargs)
 
 # If sqlalchemy-migrate is installed, register there too.
 try:


### PR DESCRIPTION
Currently it is not possible to change the column type via [alembic](https://alembic.sqlalchemy.org/en/latest/index.html). It will throw an exception like this:
```
 ...
  File "/home/ckoehn/.virtualenvs/p2/lib/python2.7/site-packages/sqlalchemy/ext/compiler.py", line 424, in _wrap_existing_dispatch
    return existing_dispatch(element, compiler, **kw)
sqlalchemy.exc.CompileError: <class 'alembic.ddl.postgresql.PostgresqlColumnType'> construct has no default compilation handler.
```

To mitigate this I registered a compiler function for the `cockroachdb` dialect  which basically passes all arguments to the respective postgres compiler :tada: 