### PR TITLE
Add support for computed columns

### DIFF
--- a/cockroachdb/sqlalchemy/ddl_compiler.py
+++ b/cockroachdb/sqlalchemy/ddl_compiler.py
@@ -1,0 +1,16 @@
+from sqlalchemy import exc
+from sqlalchemy.dialects.postgresql.base import PGDDLCompiler
+
+
+class CockroachDDLCompiler(PGDDLCompiler):
+    def visit_computed_column(self, generated):
+        if generated.persisted is False:
+            raise exc.CompileError(
+                "CockroachDB computed columns do not support 'virtual' "
+                "persistence; set the 'persisted' flag to None or True for "
+                "CockroachDB support."
+            )
+
+        return "AS (%s) STORED" % self.sql_compiler.process(
+            generated.sqltext, include_table=False, literal_binds=True
+        )

--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -12,6 +12,7 @@ import sqlalchemy.sql as sql
 import sqlalchemy.types as sqltypes
 
 from .stmt_compiler import CockroachCompiler, CockroachIdentifierPreparer
+from .ddl_compiler import CockroachDDLCompiler
 
 # Map type names (as returned by information_schema) to sqlalchemy type
 # objects.
@@ -97,6 +98,7 @@ class CockroachDBDialect(PGDialect_psycopg2):
     supports_sequences = False
     statement_compiler = CockroachCompiler
     preparer = CockroachIdentifierPreparer
+    ddl_compiler = CockroachDDLCompiler
 
     def __init__(self, *args, **kwargs):
         if kwargs.get("use_native_hstore", False):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 # To add/update dependencies, update test-requirements.txt.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-SQLAlchemy==1.2.10
+SQLAlchemy==1.3.11
 more-itertools==8.3.0
 mock==4.0.2
 pytest==3.7.1

--- a/test-requirements.txt.in
+++ b/test-requirements.txt.in
@@ -4,7 +4,7 @@
 # To add/update dependencies, update test-requirements.txt.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-SQLAlchemy==1.2.10 # the last known version of SQLAlchemy that passes all tests.
+SQLAlchemy==1.3.11 # the last known version of SQLAlchemy that passes all tests.
 more-itertools
 mock
 pytest==3.7.1

--- a/test/sqlalchemy/test_computed_column.py
+++ b/test/sqlalchemy/test_computed_column.py
@@ -1,0 +1,55 @@
+from sqlalchemy import Table, Column, Computed, MetaData, select, testing
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.testing import fixtures
+from sqlalchemy.types import Integer
+
+meta = MetaData()
+
+# Plain table for the core test.
+computed_table = Table('computed', meta,
+                       Column('id', Integer, primary_key=True, autoincrement=False),
+                       Column('computed_id', Integer, Computed('id * id')))
+
+
+# ORM class for the session test.
+class ComputedModel(declarative_base()):
+    __table__ = computed_table
+
+
+class ComputedColumnTest(fixtures.TestBase):
+    def setup_method(self, method):
+        meta.create_all(testing.db)
+        testing.db.execute(computed_table.insert(),
+                           [dict(id=2), dict(id=3)])
+
+    def teardown_method(self, method):
+        meta.drop_all(testing.db)
+
+    def test_computed_column(self):
+        result = []
+        query = select([computed_table.c.id,
+                        computed_table.c.computed_id])
+        for row in testing.db.execute(query):
+            result.append((row.id, row.computed_id))
+        assert result == [(2, 4), (3, 9)]
+
+
+class JSONSessionTest(fixtures.TestBase):
+    def setup_method(self, method):
+        meta.create_all(testing.db)
+        self.sessionmaker = sessionmaker(testing.db)
+        session = self.sessionmaker()
+        session.add(ComputedModel(id=2))
+        session.add(ComputedModel(id=3))
+        session.commit()
+
+    def teardown_method(self, method):
+        meta.drop_all(testing.db)
+
+    def test_json(self):
+        session = self.sessionmaker()
+        result = []
+        for row in session.query(ComputedModel).all():
+            result.append((row.id, row.computed_id))
+        assert result == [(2, 4), (3, 9)]


### PR DESCRIPTION
SQLAlchemy 1.3.11 includes support for computed column. This was already
a feature in older versions of CockroachDB.

The CockroachDB syntax differs slightly from the PostgreSQL syntax,
since it does not include `GENERATED ALWAYS AS`. See
https://github.com/cockroachdb/cockroach/issues/42418 for the difference in syntax.