### PR TITLE
Remove python2 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,24 +5,19 @@ version: 2
   command: start --insecure
 
 .x-cockroach-19.1: &cockroach-19-1
-  image: cockroachdb/cockroach:v19.1.8
+  image: cockroachdb/cockroach:v19.1.9
   command: start --insecure
 
 .x-cockroach-19.2: &cockroach-19-2
-  image: cockroachdb/cockroach:v19.2.4
+  image: cockroachdb/cockroach:v19.2.7
   command: start --insecure
 
 .x-cockroach-20.1: &cockroach-20-1
-  image: cockroachdb/cockroach-unstable:v20.1.0-beta.3
+  image: cockroachdb/cockroach:v20.1.0
   command: start --insecure
 
 .x-tox-version: &tox-version
   TOX_VERSION: 3.12.1
-
-.x-py27: &py27
-  environment:
-    TOXENV: py27
-    <<: *tox-version
 
 .x-py37: &py37
   environment:
@@ -43,34 +38,6 @@ version: 2
         command: ${HOME}/.local/bin/tox
 
 jobs:
-  test-py27-2.1:
-    docker:
-      - image: circleci/python:2.7
-      - *cockroach-2-1
-    <<: *test-steps
-    <<: *py27
-
-  test-py27-19.1:
-    docker:
-      - image: circleci/python:2.7
-      - *cockroach-19-1
-    <<: *test-steps
-    <<: *py27
-
-  test-py27-19.2:
-    docker:
-      - image: circleci/python:2.7
-      - *cockroach-19-2
-    <<: *test-steps
-    <<: *py27
-
-  test-py27-20.1:
-    docker:
-      - image: circleci/python:2.7
-      - *cockroach-20-1
-    <<: *test-steps
-    <<: *py27
-
   test-py37-2.1:
     docker:
       - image: circleci/python:3.7
@@ -117,10 +84,6 @@ workflows:
   version: 2
   test-and-lint:
     jobs:
-      - test-py27-2.1
-      - test-py27-19.1
-      - test-py27-19.2
-      - test-py27-20.1
       - test-py37-2.1
       - test-py37-19.1
       - test-py37-19.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,35 +4,37 @@
 # generated dev-requirements.txt), run make update-requirements,
 # then re-run bootstrap.sh.
 
-flake8==3.7.7
-tox==3.13.1
+flake8==3.8.1
+tox==3.15.1
 # Twine is used in the release process to upload the package.
-twine==1.13.0
+twine==3.1.1
 ## The following requirements were added by pip freeze:
-bleach==3.1.4
-certifi==2019.6.16
+appdirs==1.4.4
+bleach==3.1.5
+certifi==2020.4.5.1
 chardet==3.0.4
-docutils==0.14
-entrypoints==0.3
+distlib==0.3.0
+docutils==0.16
 filelock==3.0.12
-idna==2.8
-importlib-metadata==0.18
+idna==2.9
+importlib-metadata==1.6.0
+keyring==21.2.1
 mccabe==0.6.1
-packaging==19.0
+packaging==20.4
 pkginfo==1.5.0.1
-pluggy==0.12.0
-py==1.8.0
-pycodestyle==2.5.0
-pyflakes==2.1.1
-Pygments==2.4.2
-pyparsing==2.4.0
-readme-renderer==24.0
-requests==2.22.0
+pluggy==0.13.1
+py==1.8.1
+pycodestyle==2.6.0
+pyflakes==2.2.0
+Pygments==2.6.1
+pyparsing==2.4.7
+readme-renderer==26.0
+requests==2.23.0
 requests-toolbelt==0.9.1
-six==1.12.0
-toml==0.10.0
-tqdm==4.32.2
-urllib3==1.25.3
-virtualenv==16.6.1
+six==1.14.0
+toml==0.10.1
+tqdm==4.46.0
+urllib3==1.25.9
+virtualenv==20.0.21
 webencodings==0.5.1
-zipp==0.5.1
+zipp==3.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,16 +5,16 @@
 # generated test-requirements.txt) and run make update-requirements
 
 SQLAlchemy==1.2.10
-more-itertools==5.0.0
-mock==3.0.5
+more-itertools==8.3.0
+mock==4.0.2
 pytest==3.7.1
 futures==3.1.1
-psycopg2==2.8.3
+psycopg2==2.8.5
 ## The following requirements were added by pip freeze:
-atomicwrites==1.3.0
-attrs==19.1.0
-importlib-metadata==0.18
-pluggy==0.12.0
-py==1.8.0
-six==1.12.0
-zipp==0.5.1
+atomicwrites==1.4.0
+attrs==19.3.0
+importlib-metadata==1.6.0
+pluggy==0.13.1
+py==1.8.1
+six==1.14.0
+zipp==3.1.0

--- a/test-requirements.txt.in
+++ b/test-requirements.txt.in
@@ -5,7 +5,7 @@
 # generated test-requirements.txt) and run make update-requirements
 
 SQLAlchemy==1.2.10 # the last known version of SQLAlchemy that passes all tests.
-more-itertools==5.0.0 #using older version to preserve Python 2.7 support.
+more-itertools
 mock
 pytest==3.7.1
 futures


### PR DESCRIPTION
Remove python2 CI tests and update requirements.

This also updates the CockroachDB versions under test.