### PR TITLE
Add additional helpers for testing support

### DIFF
--- a/cockroachdb/sqlalchemy/provision.py
+++ b/cockroachdb/sqlalchemy/provision.py
@@ -1,0 +1,6 @@
+from sqlalchemy.testing.provision import temp_table_keyword_args
+
+
+@temp_table_keyword_args.for_db("cockroachdb")
+def _cockroachdb_temp_table_keyword_args(cfg, eng):
+    return {"prefixes": ["TEMPORARY"]}

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -76,3 +76,11 @@ class Requirements(SuiteRequirements):
     order_by_label_with_expression = exclusions.open()
     order_by_col_from_union = exclusions.open()
     implicitly_named_constraints = exclusions.open()
+
+    def get_isolation_levels(self, config):
+        return {
+            "default": "SERIALIZABLE",
+            "supported": [
+                "SERIALIZABLE"
+            ]
+        }


### PR DESCRIPTION
- Implement get_isolation_levels to indicate to tests which levels are
supported.
- Implement temp_table_keyword_args to instruct tests how to make temp
tables.