### PR TITLE
Support computed columns in older CockroachDB versions

### DIFF
--- a/cockroachdb/sqlalchemy/ddl_compiler.py
+++ b/cockroachdb/sqlalchemy/ddl_compiler.py
@@ -1,0 +1,17 @@
+from sqlalchemy import exc
+from sqlalchemy.dialects.postgresql.base import PGDDLCompiler
+
+
+class CockroachDDLCompiler(PGDDLCompiler):
+    def visit_computed_column(self, generated):
+        if generated.persisted is False:
+            raise exc.CompileError(
+                "CockroachDB computed columns do not support 'virtual' "
+                "persistence; set the 'persisted' flag to None or True for "
+                "CockroachDB support."
+            )
+
+        print('sqltext', generated.sqltext)
+        return "AS (%s) STORED" % self.sql_compiler.process(
+            generated.sqltext, include_table=False, literal_binds=True
+        )

--- a/cockroachdb/sqlalchemy/test_requirements.py
+++ b/cockroachdb/sqlalchemy/test_requirements.py
@@ -72,6 +72,19 @@ class Requirements(SuiteRequirements):
     update_from = exclusions.open()
     mod_operator_as_percent_sign = exclusions.open()
     foreign_key_constraint_reflection = exclusions.open()
+    computed_columns = \
+        exclusions.skip_if(lambda config: not config.db.dialect._is_v191plus,
+                           "versions before 19.1 do not support reflection on computed columns")
+    computed_columns_stored = \
+        exclusions.skip_if(lambda config: not config.db.dialect._is_v191plus,
+                           "versions before 19.1 do not support reflection on computed columns")
+    computed_columns_default_persisted = \
+        exclusions.skip_if(lambda config: not config.db.dialect._is_v191plus,
+                           "versions before 19.1 do not support reflection on computed columns")
+    computed_columns_reflect_persisted = \
+        exclusions.skip_if(lambda config: not config.db.dialect._is_v191plus,
+                           "versions before 19.1 do not support reflection on computed columns")
+    computed_columns_virtual = exclusions.closed()
     ctes = exclusions.skip_if(lambda config: not config.db.dialect._is_v201plus,
                               "versions before 20.x do not fully support CTEs.")
     ctes_with_update_delete = \


### PR DESCRIPTION
- Add a DDL compiler for CockroachDB so the computed column syntax without
  `GENERATED ALWAYS AS` is used.
- Enable computed column tests.
- Populate `autoincrement` property, since it's required by the computed
  column tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/sqlalchemy-cockroachdb/119)
<!-- Reviewable:end -->
