### PR TITLE
Remove `duplicates_constraint` value for unique indexes

### DIFF
--- a/cockroachdb/sqlalchemy/dialect.py
+++ b/cockroachdb/sqlalchemy/dialect.py
@@ -257,7 +257,9 @@ class CockroachDBDialect(PGDialect_psycopg2):
     def get_indexes(self, conn, table_name, schema=None, **kw):
         if self._is_v192plus:
             indexes = super().get_indexes(conn, table_name, schema, **kw)
-            # We need to remove the `duplicates_constraints` value from unique indexes, otherwise
+            # CockroachDB creates a UNIQUE INDEX automatically for each UNIQUE CONSTRAINT, and
+            # there is no difference between unique indexes and unique constraints.  We need
+            # to remove the `duplicates_constraints` value from unique indexes, otherwise
             # alembic tries to delete and recreate unique indexes.  This is consistent with
             # postgresql which doesn't set the duplicates_constraint flag on unique indexes
             for index in indexes:


### PR DESCRIPTION
In PostgreSQL, unlike CockroachDB, the pg_constraints table doesn't
contain any entries for unique indexes, which means that the `get_indexes`
function doesn't return the `duplicates_constraint` value for unique
indexes.

The alembic PostgreSQL driver, used for both PostgreSQL and CockroachDB,
filters out any indexes that have the `duplicates_constraint` value set,
which causes Alembic to believe that the constraint has been converted
into an index, rather than recognizing that they're the same thing.

This commit fixes the problem by manually filtering out the
`duplicates_constraint` value for all unique indexes.

Signed-off-by: Jonathan Dieter <jonathan.dieter@spearline.com>