### PR TITLE
Test against v21.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,19 @@
 version: 2
 
-.x-cockroach-19.1: &cockroach-19-1
-  image: cockroachdb/cockroach:v19.1.11
-  command: start --insecure
-
 .x-cockroach-19.2: &cockroach-19-2
-  image: cockroachdb/cockroach:v19.2.10
+  image: cockroachdb/cockroach:v19.2.12
   command: start-single-node --insecure
 
 .x-cockroach-20.1: &cockroach-20-1
-  image: cockroachdb/cockroach:v20.1.5
+  image: cockroachdb/cockroach:v20.1.14
   command: start-single-node --insecure
 
 .x-cockroach-20.2: &cockroach-20-2
-  image: cockroachdb/cockroach-unstable:v20.2.0-alpha.3
+  image: cockroachdb/cockroach:v20.2.7
+  command: start-single-node --insecure
+
+.x-cockroach-21.1: &cockroach-21-1
+  image: cockroachdb/cockroach-unstable:v21.1.0-beta.4
   command: start-single-node --insecure
 
 .x-tox-version: &tox-version
@@ -38,13 +38,6 @@ version: 2
         command: ${HOME}/.local/bin/tox
 
 jobs:
-  test-py37-19.1:
-    docker:
-      - image: circleci/python:3.7
-      - *cockroach-19-1
-    <<: *test-steps
-    <<: *py37
-
   test-py37-19.2:
     docker:
       - image: circleci/python:3.7
@@ -66,6 +59,13 @@ jobs:
     <<: *test-steps
     <<: *py37
 
+  test-py37-21.1:
+    docker:
+      - image: circleci/python:3.7
+      - *cockroach-21-1
+    <<: *test-steps
+    <<: *py37
+
   lint:
     docker:
       - image: circleci/python:3.7
@@ -84,8 +84,8 @@ workflows:
   version: 2
   test-and-lint:
     jobs:
-      - test-py37-19.1
       - test-py37-19.2
       - test-py37-20.1
       - test-py37-20.2
+      - test-py37-21.1
       - lint


### PR DESCRIPTION
- Remove v19.1 from testing since it has reached end of life.
- Update other versions under test to latest patch release.