### PR TITLE
Update test pipeline to Python 3.9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,9 @@ version: 2
 .x-tox-version: &tox-version
   TOX_VERSION: 3.12.1
 
-.x-py37: &py37
+.x-py39: &py39
   environment:
-    TOXENV: py37
+    TOXENV: py39
     <<: *tox-version
 
 .x-test-steps: &test-steps
@@ -38,37 +38,37 @@ version: 2
         command: ${HOME}/.local/bin/tox
 
 jobs:
-  test-py37-19.2:
+  test-py39-19.2:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
       - *cockroach-19-2
     <<: *test-steps
-    <<: *py37
+    <<: *py39
 
-  test-py37-20.1:
+  test-py39-20.1:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
       - *cockroach-20-1
     <<: *test-steps
-    <<: *py37
+    <<: *py39
 
-  test-py37-20.2:
+  test-py39-20.2:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
       - *cockroach-20-2
     <<: *test-steps
-    <<: *py37
+    <<: *py39
 
-  test-py37-21.1:
+  test-py39-21.1:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
       - *cockroach-21-1
     <<: *test-steps
-    <<: *py37
+    <<: *py39
 
   lint:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     environment:
       <<: *tox-version
     steps:
@@ -84,8 +84,8 @@ workflows:
   version: 2
   test-and-lint:
     jobs:
-      - test-py37-19.2
-      - test-py37-20.1
-      - test-py37-20.2
-      - test-py37-21.1
+      - test-py39-19.2
+      - test-py39-20.1
+      - test-py39-20.2
+      - test-py39-21.1
       - lint

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ install_command=python -m pip install {env:TOX_PIP_OPTS:} {opts} {packages} -r t
 [testenv:lint]
 skip_install = True
 deps =
-  flake8==3.6.0
+  flake8==3.9.2
 commands =
   flake8 sqlalchemy_cockroachdb test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # We do not currently test with pypy because psycopg2 does not work there.
 envlist =
-  py37
+  py39
   lint
 
 [testenv]


### PR DESCRIPTION
If your rather want to stick to Python 3.7 or want to test with multiple versions (eg. latest 2-3 versions) that's up to you. Keep in mind that multiple versions will significantly increase the CircleCI usage and the size of the pipeline configuration.

List of EOL dates: https://endoflife.date/python

**Update**
To mitigate `AttributeError: 'FlakesChecker' object has no attribute 'CONSTANT'` I had to update `flake8` to the latest version.