### PR TITLE
Add Alembic test suite support

### DIFF
--- a/README.testing.md
+++ b/README.testing.md
@@ -1,4 +1,4 @@
-## Testing this dialect with SQLAlchemy
+## Testing this dialect with SQLAlchemy and Alembic
 
 "setup.cfg" contains a default SQLAlchemy connection URI that should
 work if you have a local instance of CockroachDB installed:
@@ -14,6 +14,7 @@ folder as "setup.cfg", copy the ``[db]`` section into it, and adjust the
 The minimum requirements for testing are:
 
 - SQLAlchemy,
+- Alembic,
 - pytest, and
 - the psycopg2 DBAPI module.
 
@@ -21,11 +22,23 @@ Install them with
 
     pip install sqlalchemy pytest psycopg2-binary
 
+    # A pre-release version of Alembic is required until version 1.7 is released.
+    # (Bear this in mind if you rebuild test-requirements.txt via make.)
+    pip install git+https://github.com/sqlalchemy/alembic
+
 Then, to run a complete test simply invoke
 
     pytest
 
 at a command prompt in your virtual environment.
+
+To run just the SQLAlchemy test suite, use
+
+    pytest test/test_suite_sqlalchemy.py
+
+and to run just the Alembic test suite, use
+
+    pytest test/test_suite_alembic.py
 
 For more detailed information see the corresponding SQLAlchemy document
 

--- a/sqlalchemy_cockroachdb/requirements.py
+++ b/sqlalchemy_cockroachdb/requirements.py
@@ -1,9 +1,10 @@
-from sqlalchemy.testing.requirements import SuiteRequirements
+from sqlalchemy.testing.requirements import SuiteRequirements as SuiteRequirementsSQLA
+from alembic.testing.requirements import SuiteRequirements as SuiteRequirementsAlembic
 
 from sqlalchemy.testing import exclusions
 
 
-class Requirements(SuiteRequirements):
+class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
     # This class configures the sqlalchemy test suite. Oddly, it must
     # be importable in the main codebase and not alongside the tests.
     #

--- a/sqlalchemy_cockroachdb/requirements.py
+++ b/sqlalchemy_cockroachdb/requirements.py
@@ -157,3 +157,9 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
 
     def get_isolation_levels(self, config):
         return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE"]}
+
+# non-default requirements for Alembic test suite
+
+    @property
+    def autoincrement_on_composite_pk(self):
+        return exclusions.open()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,8 @@
 # generated test-requirements.txt) and run make update-requirements
 
 SQLAlchemy==1.4.17
+# temporary tweak required until Alembic 1.7 is released:
+git+https://github.com/sqlalchemy/alembic
 more-itertools==8.8.0
 mock==4.0.3
 pytest==6.2.4
@@ -22,3 +24,7 @@ pyparsing==2.4.7
 toml==0.10.2
 typing-extensions==3.10.0.0
 zipp==3.4.1
+Mako
+python-editor>=0.3
+python-dateutil
+six

--- a/test-requirements.txt.in
+++ b/test-requirements.txt.in
@@ -5,6 +5,9 @@
 # generated test-requirements.txt) and run make update-requirements
 
 SQLAlchemy
+# a temporary tweak in test-requirements.txt is required until Alembic 1.7 is released:
+# git+https://github.com/sqlalchemy/alembic
+alembic
 more-itertools
 mock
 pytest

--- a/test/test_suite_alembic.py
+++ b/test/test_suite_alembic.py
@@ -1,0 +1,90 @@
+from alembic.testing.suite import *  # noqa
+from sqlalchemy.testing import skip
+from alembic.testing.suite import AutogenerateFKOptionsTest as _AutogenerateFKOptionsTest
+from alembic.testing.suite import AutogenerateForeignKeysTest as _AutogenerateForeignKeysTest
+from alembic.testing.suite import BackendAlterColumnTest as _BackendAlterColumnTest
+from alembic.testing.suite import IncludeHooksTest as _IncludeHooksTest
+
+
+class AutogenerateFKOptionsTest(_AutogenerateFKOptionsTest):
+    def test_change_ondelete_from_restrict(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_change_ondelete_from_restrict()
+
+    def test_change_onupdate_from_restrict(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_change_onupdate_from_restrict()
+
+    def test_nochange_ondelete(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_ondelete()
+
+    def test_nochange_ondelete_noaction(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_ondelete_noaction()
+
+    def test_nochange_ondelete_restrict(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_ondelete_restrict()
+
+    def test_nochange_onupdate(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_onupdate()
+
+    def test_nochange_onupdate_noaction(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_onupdate_noaction()
+
+    def test_nochange_onupdate_restrict(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_nochange_onupdate_restrict()
+
+
+class AutogenerateForeignKeysTest(_AutogenerateForeignKeysTest):
+    def test_casing_convention_changed_so_put_drops_first(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_casing_convention_changed_so_put_drops_first()
+
+    def test_no_change(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_no_change()
+
+    def test_no_change_colkeys(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_no_change_colkeys()
+
+    def test_no_change_composite_fk(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_no_change_composite_fk()
+
+    def test_remove_composite_fk(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_remove_composite_fk()
+
+    def test_remove_fk(self):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_remove_fk()
+
+
+class BackendAlterColumnTest(_BackendAlterColumnTest):
+    def test_modify_nullable_to_non(self):
+        # we seem to need autocommit for this operation
+        with self.op.get_context().autocommit_block():
+            super().test_modify_nullable_to_non()
+
+    @skip("cockroachdb")  # noqa
+    def test_modify_type_int_str(self):
+        # TODO: enable this test when warning removed for ALTER COLUMN int → string
+        pass
+
+
+class IncludeHooksTest(_IncludeHooksTest):
+    @combinations(("object",), ("name",))  # noqa
+    def test_change_fk(self, hook_type):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_change_fk(hook_type)
+
+    @combinations(("object",), ("name",))  # noqa
+    def test_remove_connection_fk(self, hook_type):
+        if config.db.dialect._is_v202plus:  # noqa
+            super().test_remove_connection_fk(hook_type)

--- a/test/test_suite_sqlalchemy.py
+++ b/test/test_suite_sqlalchemy.py
@@ -1,4 +1,5 @@
 from sqlalchemy import __version__ as sa_version
+from sqlalchemy.testing import skip
 from sqlalchemy.testing.suite import *  # noqa
 from sqlalchemy.testing.suite import ComponentReflectionTest as _ComponentReflectionTest
 from sqlalchemy.testing.suite import ExpandingBoundInTest as _ExpandingBoundInTest
@@ -11,7 +12,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
 
 class ExpandingBoundInTest(_ExpandingBoundInTest):
-    @testing.skip("cockroachdb")  # noqa
+    @skip("cockroachdb")  # noqa
     def test_null_in_empty_set_is_false(self, connection):
         # Fixed in https://github.com/cockroachdb/cockroach/pull/49814
         # Unskip when backported.


### PR DESCRIPTION
Currently using a pre-release version of Alembic.

pip install from GitHub instead of PyPI until
Alembic 1.7 is released.