### PR TITLE
Use Python 3 syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup, find_packages
 with open(os.path.join(os.path.dirname(__file__), "sqlalchemy_cockroachdb", "__init__.py")) as v:
     VERSION = re.compile(r'.*__version__ = "(.*?)"', re.S).match(v.read()).group(1)
 
-readme = os.path.join(os.path.dirname(__file__), "README.md")
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
+    README = f.read()
 
 setup(
     name="sqlalchemy-cockroachdb",
@@ -15,13 +16,17 @@ setup(
     author_email="cockroach-db@googlegroups.com",
     url="https://github.com/cockroachdb/sqlalchemy-cockroachdb",
     description="CockroachDB dialect for SQLAlchemy",
-    long_description=open(readme).read(),
+    long_description=README,
     long_description_content_type="text/markdown",
     license="http://www.apache.org/licenses/LICENSE-2.0",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords="SQLAlchemy CockroachDB",
     project_urls={

--- a/sqlalchemy_cockroachdb/base.py
+++ b/sqlalchemy_cockroachdb/base.py
@@ -103,7 +103,7 @@ class CockroachDBDialect(PGDialect):
         **kwargs,
     ):
         self.disable_cockroachdb_telemetry = disable_cockroachdb_telemetry
-        return super(CockroachDBDialect, self).connect(
+        return super().connect(
             dsn, connection_factory,
             cursor_factory, **kwargs)
 
@@ -114,7 +114,7 @@ class CockroachDBDialect(PGDialect):
             raise NotImplementedError("server_side_cursors is not supported")
         kwargs["use_native_hstore"] = False
         kwargs["server_side_cursors"] = False
-        super(CockroachDBDialect, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def dbapi(cls):
@@ -151,7 +151,7 @@ class CockroachDBDialect(PGDialect):
             version = pkg_resources.require("sqlalchemy-cockroachdb")[0].version
             telemetry_query = (
                 "SELECT crdb_internal.increment_feature_counter"
-                + "('SQLAlchemy {version}')".format(version=version)
+                + f"('SQLAlchemy {version}')"
             )
             connection.execute(text(telemetry_query))
 
@@ -190,7 +190,7 @@ class CockroachDBDialect(PGDialect):
             # Oh well. Hoping 1.1 won't be around for long.
             rows = conn.execute(
                 text(
-                    'SHOW COLUMNS FROM "%s"."%s"' % (schema or self.default_schema_name, table_name)
+                    f'SHOW COLUMNS FROM "{schema or self.default_schema_name}"."{table_name}"'
                 )
             )
         elif not self._is_v191plus:
@@ -234,7 +234,7 @@ class CockroachDBDialect(PGDialect):
                 try:
                     type_class = _type_map[type_name.lower()]
                 except KeyError:
-                    warn("Did not recognize type '%s' of column '%s'" % (type_name, name))
+                    warn(f"Did not recognize type '{type_name}' of column '{name}'")
                     type_class = sqltypes.NULLTYPE
                 if type_args:
                     typ = type_class(*[int(s.strip()) for s in type_args.split(",")])
@@ -350,7 +350,7 @@ class CockroachDBDialect(PGDialect):
 
         for row in conn.execute(
             text(
-                'SHOW CONSTRAINTS FROM "%s"."%s"' % (schema or self.default_schema_name, table_name)
+                f'SHOW CONSTRAINTS FROM "{schema or self.default_schema_name}"."{table_name}"'
             )
         ):
             if row.Type.startswith("FOREIGN KEY"):
@@ -483,7 +483,7 @@ class CockroachDBDialect(PGDialect):
 
     def get_pk_constraint(self, conn, table_name, schema=None, **kw):
         if self._is_v21plus:
-            return super(CockroachDBDialect, self).get_pk_constraint(conn, table_name, schema, **kw)
+            return super().get_pk_constraint(conn, table_name, schema, **kw)
 
         # v2.0 does not know about enough SQL to understand the query done by
         # the upstream dialect. So run a dumbed down version instead.
@@ -505,7 +505,7 @@ class CockroachDBDialect(PGDialect):
 
     def get_unique_constraints(self, conn, table_name, schema=None, **kw):
         if self._is_v21plus:
-            return super(CockroachDBDialect, self).get_unique_constraints(
+            return super().get_unique_constraints(
                 conn, table_name, schema, **kw
             )
 
@@ -525,7 +525,7 @@ class CockroachDBDialect(PGDialect):
 
     def get_check_constraints(self, conn, table_name, schema=None, **kw):
         if self._is_v21plus:
-            return super(CockroachDBDialect, self).get_check_constraints(
+            return super().get_check_constraints(
                 conn, table_name, schema, **kw
             )
         # TODO(bdarnell): The postgres dialect implementation depends on
@@ -538,21 +538,21 @@ class CockroachDBDialect(PGDialect):
         if savepoint_state.cockroach_restart:
             connection.execute(text("SAVEPOINT cockroach_restart"))
         else:
-            super(CockroachDBDialect, self).do_savepoint(connection, name)
+            super().do_savepoint(connection, name)
 
     def do_rollback_to_savepoint(self, connection, name):
         # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:
             connection.execute(text("ROLLBACK TO SAVEPOINT cockroach_restart"))
         else:
-            super(CockroachDBDialect, self).do_rollback_to_savepoint(connection, name)
+            super().do_rollback_to_savepoint(connection, name)
 
     def do_release_savepoint(self, connection, name):
         # Savepoint logic customized to work with run_transaction().
         if savepoint_state.cockroach_restart:
             connection.execute(text("RELEASE SAVEPOINT cockroach_restart"))
         else:
-            super(CockroachDBDialect, self).do_release_savepoint(connection, name)
+            super().do_release_savepoint(connection, name)
 
 
 # If alembic is installed, register an alias in its dialect mapping.

--- a/sqlalchemy_cockroachdb/stmt_compiler.py
+++ b/sqlalchemy_cockroachdb/stmt_compiler.py
@@ -90,7 +90,7 @@ crdb_grammar_reserved = """
 | WITH
 | WORK
 """
-CRDB_RESERVED_WORDS = set([x.strip().lower() for x in crdb_grammar_reserved.split("|")])
+CRDB_RESERVED_WORDS = {x.strip().lower() for x in crdb_grammar_reserved.split("|")}
 
 
 class CockroachIdentifierPreparer(PGIdentifierPreparer):

--- a/sqlalchemy_cockroachdb/transaction.py
+++ b/sqlalchemy_cockroachdb/transaction.py
@@ -44,7 +44,7 @@ def run_transaction(transactor, callback, max_retries=None, max_backoff=0):
         raise TypeError("don't know how to run a transaction on %s", type(transactor))
 
 
-class _NestedTransaction(object):
+class _NestedTransaction:
     """Wraps begin_nested() to set the savepoint_state thread-local.
 
     This causes the savepoint statements that are a part of this retry


### PR DESCRIPTION
Python 2 support has been dropped since 1.3.0 which allows us to use some of the new language features. The automatic update has been conducted with [pyupgrade](https://github.com/asottile/pyupgrade):

```
pyupgrade --py36-plus <FILES>
```