### PR TITLE
Updates for current SQLAlchemy/Alembic versions

### DIFF
--- a/README.testing.md
+++ b/README.testing.md
@@ -20,11 +20,7 @@ The minimum requirements for testing are:
 
 Install them with 
 
-    pip install sqlalchemy pytest psycopg2-binary
-
-    # A pre-release version of Alembic is required until version 1.7 is released.
-    # (Bear this in mind if you rebuild test-requirements.txt via make.)
-    pip install git+https://github.com/sqlalchemy/alembic
+    pip install sqlalchemy alembic pytest psycopg2-binary
 
 Then, to run a complete test simply invoke
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,8 +4,7 @@
 # To add/update dependencies, update test-requirements.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-# Remove this once alembic 1.7 has been released
-git+https://github.com/sqlalchemy/alembic
+alembic
 futures
 mock
 more-itertools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/sqlalchemy/alembic
+alembic==1.7.0
     # via -r test-requirements.in
 attrs==21.2.0
     # via pytest

--- a/test/test_aaa_run_transaction_session.py
+++ b/test/test_aaa_run_transaction_session.py
@@ -47,7 +47,7 @@ class BaseRunTransactionTest(fixtures.TestBase):
         """Returns the balances of the two accounts as a list."""
         result = []
         query = (
-            select([account_table.c.balance])
+            select(account_table.c.balance)
             .where(account_table.c.acct.in_((1, 2)))
             .order_by(account_table.c.acct)
         )
@@ -96,7 +96,7 @@ class BaseRunTransactionTest(fixtures.TestBase):
             iters1,
             iters2,
         )
-        balances = self.get_balances(testing.db)
+        balances = self.get_balances(testing.db.connect())
         assert balances == [100, 100], (
             "expected balances to be restored without error; " "got %s" % balances
         )

--- a/test/test_aab_run_transaction_core.py
+++ b/test/test_aab_run_transaction_core.py
@@ -35,7 +35,7 @@ class BaseRunTransactionTest(fixtures.TestBase):
         """Returns the balances of the two accounts as a list."""
         result = []
         query = (
-            select([account_table.c.balance])
+            select(account_table.c.balance)
             .where(account_table.c.acct.in_((1, 2)))
             .order_by(account_table.c.acct)
         )
@@ -84,7 +84,7 @@ class BaseRunTransactionTest(fixtures.TestBase):
             iters1,
             iters2,
         )
-        balances = self.get_balances(testing.db)
+        balances = self.get_balances(testing.db.connect())
         assert balances == [100, 100], (
             "expected balances to be restored without error; " "got %s" % balances
         )

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -37,9 +37,7 @@ class JSONTest(fixtures.TablesTest):
             return
         json_table = self.tables.json_model
         result = []
-        query = select(
-            [json_table.c.jsonb_data, json_table.c.json_data, json_table.c.base_json_data]
-        )
+        query = select(json_table.c.jsonb_data, json_table.c.json_data, json_table.c.base_json_data)
         for row in connection.execute(query):
             result.append((row.jsonb_data, row.json_data, row.base_json_data))
         eq_(result, [({"a": 1}, {"b": 2}, {"c": 3}), ({"d": 4}, {"e": 5}, {"f": 6})])

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-  python -m pytest {posargs}
+  python -m pytest {posargs} test
 # For some reason pip fails to load the requirements file without this.
 setenv =
   LANG = en_US.utf-8


### PR DESCRIPTION
Alembic: Version 1.7 has been released so we no
longer need to install from GitHub to have access
to the test suite.

SQLAlchemy: 2.0 deprecation warnings are now
being emitted where they were previously being
automatically suppressed. Adjust tests to avoid
the warnings, so they do not cause the tests to
fail.