### PR TITLE
Adjust test_run_transaction_session.py for 1.4

### DIFF
--- a/test/test_run_transaction_core.py
+++ b/test/test_run_transaction_core.py
@@ -6,10 +6,6 @@ import threading
 
 from sqlalchemy_cockroachdb import run_transaction
 
-""" This file is named "test_aab_run_transaction_core.py" to keep it close to its more
-    temperamental "session" sibling.
-"""
-
 meta = MetaData()
 
 account_table = Table(


### PR DESCRIPTION
Restructure tests to avoid requirement that they
must be run before any other tests. Rename .py
files accordingly.