### PR TITLE
Stop sending telemetry on startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 Released February ??, 2023
 
 - Applied dialect code and test changes for compatibility with SQLAlchemy 2.0. This
-version of the dialect requires SQLAlchemy 2.0, so to work with earlier versions of
-SQLAlchemy use `pip install sqlalchemy-cockroachdb<2.0.0`
+  version of the dialect requires SQLAlchemy 2.0, so to work with earlier versions of
+  SQLAlchemy use `pip install sqlalchemy-cockroachdb<2.0.0`
+- Stopped sending telemetry data during startup.
 
 # Version 1.4.4
 Released September 9, 2022

--- a/README.testing.md
+++ b/README.testing.md
@@ -4,7 +4,7 @@
 work if you have a local instance of CockroachDB installed:
 
     [db]
-    default=cockroachdb://root@localhost:26257/defaultdb?disable_cockroachdb_telemetry=True
+    default=cockroachdb://root@localhost:26257/defaultdb
 
 If you want to test against a remote server (or otherwise need to tweak
 the connection URI) simply create a file named "test.cfg" in the same

--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,15 @@
 version: 2
 
-.x-cockroach-21.1: &cockroach-21-1
-  image: cockroachdb/cockroach:v21.1.19
-  command: start-single-node --insecure
-
 .x-cockroach-21.2: &cockroach-21-2
   image: cockroachdb/cockroach:v21.2.15
   command: start-single-node --insecure
 
 .x-cockroach-22.1: &cockroach-22-1
-  image: cockroachdb/cockroach:v22.1.6
+  image: cockroachdb/cockroach:v22.1.14
   command: start-single-node --insecure
 
 .x-cockroach-22.2: &cockroach-22-2
-  image: cockroachdb/cockroach-unstable:v22.2.0-alpha.2
+image: cockroachdb/cockroach:v22.2.3
   command: start-single-node --insecure
 
 .x-tox-version: &tox-version
@@ -38,13 +34,6 @@ version: 2
         command: ${HOME}/.local/bin/tox
 
 jobs:
-  test-py39-21.1:
-    docker:
-      - image: circleci/python:3.9
-      - *cockroach-21-1
-    <<: *test-steps
-    <<: *py39
-
   test-py39-21.2:
     docker:
       - image: circleci/python:3.9
@@ -86,7 +75,6 @@ workflows:
   version: 2
   test-and-lint:
     jobs:
-      - test-py39-21.1
       - test-py39-21.2
       - test-py39-22.1
       - test-py39-22.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ requirement_cls = sqlalchemy_cockroachdb.requirements:Requirements
 profile_file=test/profiles.txt
 
 [db]
-default=cockroachdb://root@localhost:26257/defaultdb?disable_cockroachdb_telemetry=True
+default=cockroachdb://root@localhost:26257/defaultdb
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
We no longer have a need for this data, and it adds network calls during startup, so it's undesirable.