### PR TITLE
Preserve compatibility for disable_cockroachdb_telemetry

### DIFF
--- a/sqlalchemy_cockroachdb/base.py
+++ b/sqlalchemy_cockroachdb/base.py
@@ -92,6 +92,15 @@ class CockroachDBDialect(PGDialect):
     preparer = CockroachIdentifierPreparer
     ddl_compiler = CockroachDDLCompiler
 
+    # Override connect so we can take disable_cockroachdb_telemetry as a connect_arg to sqlalchemy.
+    # The option is not used any more, but removing it is a backwards-incompatible change.
+    def connect(
+        self,
+        disable_cockroachdb_telemetry=False,
+        **kwargs,
+    ):
+        return super().connect(**kwargs)
+
     def __init__(self, *args, **kwargs):
         if kwargs.get("use_native_hstore", False):
             raise NotImplementedError("use_native_hstore is not supported")


### PR DESCRIPTION
Removing it entirely could mean that people who still include the option see the error:

sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) invalid dsn: invalid connection option "disable_cockroachdb_telemetry"

when connecting.