### PR TITLE
Add the `synchronize` PR type to the test/lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - "*"
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This makes the workflow run on every update pushed to a PR.