### PR TITLE
Enable AUTOCOMMIT isolation_level for SQLA 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Version 2.0.1
 Unreleased
 
+- Enable AUTOCOMMIT isolation_level for SQLA 2.0 (#205)
 
 # Version 2.0.0
 Released February 21, 2023

--- a/sqlalchemy_cockroachdb/_psycopg_common.py
+++ b/sqlalchemy_cockroachdb/_psycopg_common.py
@@ -5,4 +5,4 @@ class _CockroachDBDialect_common_psycopg(CockroachDBDialect):
     supports_sane_rowcount = False  # for psycopg2, at least
 
     def get_isolation_level_values(self, dbapi_conn):
-        return ("SERIALIZABLE",)
+        return ("SERIALIZABLE", "AUTOCOMMIT")

--- a/sqlalchemy_cockroachdb/asyncpg.py
+++ b/sqlalchemy_cockroachdb/asyncpg.py
@@ -18,4 +18,4 @@ class CockroachDBDialect_asyncpg(PGDialect_asyncpg, CockroachDBDialect):
         pass
 
     def get_isolation_level_values(self, dbapi_conn):
-        return ("SERIALIZABLE",)
+        return ("SERIALIZABLE", "AUTOCOMMIT")

--- a/sqlalchemy_cockroachdb/requirements.py
+++ b/sqlalchemy_cockroachdb/requirements.py
@@ -175,9 +175,15 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
         return exclusions.open()
 
     def get_isolation_levels(self, config):
-        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE"]}
+        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE", "AUTOCOMMIT"]}
 
+    @property
+    def autocommit(self):
+        return exclusions.open()
+
+    # -----------------------------------------------
     # non-default requirements for Alembic test suite
+    # -----------------------------------------------
 
     @property
     def autoincrement_on_composite_pk(self):


### PR DESCRIPTION
Fixes: #205