### PR TITLE
Allow READ COMMITTED isolation level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         crdb-version: [
           "cockroach:latest-v22.2",
           "cockroach:latest-v23.1",
-          "cockroach-unstable:v23.2.0-beta.2"
+          "cockroach:latest-v23.2"
         ]
         db-alias: [
           "psycopg2",
@@ -53,8 +53,8 @@ jobs:
       TOXENV: py39
       TOX_VERSION: 3.23.1
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9' 
       - name: Start CockroachDB
@@ -73,8 +73,8 @@ jobs:
       TOXENV: py39
       TOX_VERSION: 3.23.1
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9' 
       - name: Install testrunner

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Version 2.0.3
 Unreleased
 
+- Add support for READ COMMITTED transaction isolation
+  (see [README.read_committed.md](README.read_committed.md))
+
 
 # Version 2.0.2
 January 10, 2023

--- a/README.read_committed.md
+++ b/README.read_committed.md
@@ -1,0 +1,40 @@
+## READ COMMITTED transaction isolation
+
+CockroachDB v23.2.0 added support for READ COMMITTED transaction isolation as
+a "preview feature", meaning that we must opt-in to activate it by sending
+the statement
+
+```
+SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true;
+```
+
+Unfortunately, SQLAlchemy's "autobegin"
+functionality prevents us from using an `@event.listens_for(Engine, "connect")`
+function as that will throw
+
+> sqlalchemy.exc.InternalError: (psycopg2.InternalError) SET CLUSTER SETTING cannot be used inside a multi-statement transaction
+
+Instead, we need to define a custom `connect=` function that we can pass to 
+`create_engine()`:
+
+```python
+import psycopg2
+from sqlalchemy import create_engine
+
+def connect_for_read_committed():
+    cnx = psycopg2.connect("host=localhost port=26257 user=root dbname=defaultdb")
+    cnx.autocommit = True
+    crs = cnx.cursor()
+    crs.execute("SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true;")
+    cnx.autocommit = False
+    return cnx
+
+engine = create_engine(
+    "cockroachdb+psycopg2://",
+    creator=connect_for_read_committed,
+    isolation_level="READ COMMITTED",
+)
+
+with engine.begin() as conn:
+    conn.exec_driver_sql("UPDATE tbl SET txt = 'SQLAlchemy' WHERE id = 1")
+```

--- a/README.read_committed.md
+++ b/README.read_committed.md
@@ -8,14 +8,11 @@ the statement
 SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true;
 ```
 
-Unfortunately, SQLAlchemy's "autobegin"
-functionality prevents us from using an `@event.listens_for(Engine, "connect")`
-function as that will throw
+This statement changes a persisted setting in the CockroachDB cluster. It is meant
+to be executed one time by a database operator/administrator.
 
-> sqlalchemy.exc.InternalError: (psycopg2.InternalError) SET CLUSTER SETTING cannot be used inside a multi-statement transaction
-
-Instead, we need to define a custom `connect=` function that we can pass to 
-`create_engine()`:
+For testing purposes, this adapter offers a custom `connect=` function that we
+can pass to  `create_engine()`, which will configure this setting:
 
 ```python
 import psycopg2

--- a/sqlalchemy_cockroachdb/_psycopg_common.py
+++ b/sqlalchemy_cockroachdb/_psycopg_common.py
@@ -5,4 +5,4 @@ class _CockroachDBDialect_common_psycopg(CockroachDBDialect):
     supports_sane_rowcount = False  # for psycopg2, at least
 
     def get_isolation_level_values(self, dbapi_conn):
-        return ("SERIALIZABLE", "AUTOCOMMIT")
+        return ("SERIALIZABLE", "AUTOCOMMIT", "READ COMMITTED")

--- a/sqlalchemy_cockroachdb/asyncpg.py
+++ b/sqlalchemy_cockroachdb/asyncpg.py
@@ -18,4 +18,4 @@ class CockroachDBDialect_asyncpg(PGDialect_asyncpg, CockroachDBDialect):
         pass
 
     def get_isolation_level_values(self, dbapi_conn):
-        return ("SERIALIZABLE", "AUTOCOMMIT")
+        return ("SERIALIZABLE", "AUTOCOMMIT", "READ COMMITTED")

--- a/sqlalchemy_cockroachdb/requirements.py
+++ b/sqlalchemy_cockroachdb/requirements.py
@@ -176,12 +176,16 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
 
     @property
     def json_deserializer_binary(self):
-        return exclusions.only_if(
-            lambda config: config.db.dialect.driver in ["psycopg"]
-        )
+        return exclusions.only_if(lambda config: config.db.dialect.driver in ["psycopg"])
 
     def get_isolation_levels(self, config):
-        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE", "AUTOCOMMIT", "READ COMMITTED"]}
+        info = {
+            "default": "SERIALIZABLE",
+            "supported": ["SERIALIZABLE", "AUTOCOMMIT"],
+        }
+        if config.db.dialect._is_v232plus:
+            info["supported"].append("READ COMMITTED")
+        return info
 
     @property
     def autocommit(self):

--- a/sqlalchemy_cockroachdb/requirements.py
+++ b/sqlalchemy_cockroachdb/requirements.py
@@ -181,7 +181,7 @@ class Requirements(SuiteRequirementsSQLA, SuiteRequirementsAlembic):
         )
 
     def get_isolation_levels(self, config):
-        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE", "AUTOCOMMIT"]}
+        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE", "AUTOCOMMIT", "READ COMMITTED"]}
 
     @property
     def autocommit(self):

--- a/test/test_suite_sqlalchemy.py
+++ b/test/test_suite_sqlalchemy.py
@@ -277,10 +277,22 @@ class InsertBehaviorTest(_InsertBehaviorTest):
 
 
 class IsolationLevelTest(_IsolationLevelTest):
+    def test_all_levels(self):
+        if not config.db.dialect._is_v232plus:
+            # TODO: enable when READ COMMITTED no longer a preview feature, since
+            #       SET CLUSTER SETTING cannot be used inside a multi-statement transaction
+            super().test_all_levels()
+
     @skip("cockroachdb")
     def test_dialect_user_setting_is_restored(self):
         # IndexError: list index out of range
         pass
+
+    def test_non_default_isolation_level(self):
+        if not config.db.dialect._is_v232plus:
+            # TODO: enable when READ COMMITTED no longer a preview feature, since
+            #       SET CLUSTER SETTING cannot be used inside a multi-statement transaction
+            super().test_non_default_isolation_level()
 
 
 class LongNameBlowoutTest(_LongNameBlowoutTest):


### PR DESCRIPTION
CockroachDB is adding support for READ COMMITTED, so it should be allowed here.

See https://www.cockroachlabs.com/docs/stable/read-committed