### PR TITLE
Fix autogenerate with ON UPDATE / DELETE

### DIFF
--- a/sqlalchemy_cockroachdb/base.py
+++ b/sqlalchemy_cockroachdb/base.py
@@ -375,9 +375,9 @@ class CockroachDBDialect(PGDialect):
             r"FOREIGN KEY \((.*?)\) "
             rf"REFERENCES (?:({qtoken})\.)?({qtoken})\(((?:{qtoken}(?: *, *)?)+)\)"  # noqa: E501
             r"[\s]?(MATCH (FULL|PARTIAL|SIMPLE)+)?"
-            r"[\s]?(ON UPDATE "
-            r"(CASCADE|RESTRICT|NO ACTION|SET NULL|SET DEFAULT)+)?"
             r"[\s]?(ON DELETE "
+            r"(CASCADE|RESTRICT|NO ACTION|SET NULL|SET DEFAULT)+)?"
+            r"[\s]?(ON UPDATE "
             r"(CASCADE|RESTRICT|NO ACTION|SET NULL|SET DEFAULT)+)?"
             r"[\s]?(DEFERRABLE|NOT DEFERRABLE)?"
             r"[\s]?(INITIALLY (DEFERRED|IMMEDIATE)+)?"


### PR DESCRIPTION
Fix an issue where the regular expression incorrectly parses the foreign key constraint in case an `onupdate` / `ondelete` is present.

Closes: #257