### PR TITLE
Compile timestampdiff() to EXTRACT(EPOCH FROM ...) on cockroachdb dialect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,17 @@ Unreleased
 - Update minimum Python version to 3.10
 - Compile MySQL-style `func.timestampdiff(unit, start, end)` to a
   PostgreSQL-style `EXTRACT(EPOCH FROM ...)` expression on the cockroachdb
-  dialect, casting the result to NUMERIC to avoid `float / decimal`
-  arithmetic errors. Enables cross-dialect ORMs (e.g. Apache Airflow) that
-  fall back to `timestampdiff` for non-PostgreSQL backends.
+  dialect. The arithmetic result is wrapped in `TRUNC()` so the value matches
+  MySQL's integer-truncation-toward-zero semantics (a 90-second diff at
+  `MINUTE` returns 1, not 1.5), and is cast to NUMERIC so callers may safely
+  combine it with integer or numeric divisors -- avoiding the `float / decimal`
+  arithmetic errors CockroachDB rejects but PostgreSQL accepts. Supported
+  units: MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK.
+  Calendar-aware units (MONTH, QUARTER, YEAR) are explicitly rejected with a
+  specific error message because they require calendar walking that cannot be
+  derived from epoch arithmetic alone. Enables cross-dialect ORMs (e.g.
+  Apache Airflow) that fall back to `timestampdiff` for non-PostgreSQL
+  backends.
 
 
 # Version 2.0.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Unreleased
 - Fix reflection of JSONB columns (#277)
 - Fix compatibility issues with Alembic 1.18 (via SQLA 2.0.47)
 - Update minimum Python version to 3.10
+- Compile MySQL-style `func.timestampdiff(unit, start, end)` to a
+  PostgreSQL-style `EXTRACT(EPOCH FROM ...)` expression on the cockroachdb
+  dialect, casting the result to NUMERIC to avoid `float / decimal`
+  arithmetic errors. Enables cross-dialect ORMs (e.g. Apache Airflow) that
+  fall back to `timestampdiff` for non-PostgreSQL backends.
 
 
 # Version 2.0.3

--- a/sqlalchemy_cockroachdb/stmt_compiler.py
+++ b/sqlalchemy_cockroachdb/stmt_compiler.py
@@ -1,6 +1,7 @@
 from sqlalchemy.dialects.postgresql.base import PGCompiler
 from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.elements import BindParameter
 from sqlalchemy.sql.functions import GenericFunction
 
 # This is extracted from CockroachDB's `sql.y`. Add keywords here if *NEW* reserved keywords
@@ -129,6 +130,27 @@ _TIMESTAMPDIFF_UNIT_FACTOR = {
 }
 
 
+def _resolve_timestampdiff_unit(unit_arg, compiler, **kwargs):
+    """Extract the unit token from a ``timestampdiff()`` first argument.
+
+    The unit must be known at compile time so it can be turned into a SQL
+    arithmetic factor. Plain Python strings (``func.timestampdiff("SECOND", ...)``)
+    and ``literal("SECOND")`` reach the compiler as :class:`BindParameter`; if we
+    delegated to ``compiler.process`` those would render as parameter
+    placeholders (``$1`` / ``%(...)s``), so we extract ``.value`` directly.
+    Other constructs such as ``text("SECOND")`` and ``literal_column("SECOND")``
+    render as literal SQL tokens and go through the normal path.
+    """
+    if isinstance(unit_arg, BindParameter):
+        raw = unit_arg.value
+        if not isinstance(raw, str):
+            raise ValueError(
+                "timestampdiff() unit must be a string; " f"got {type(raw).__name__} ({raw!r})"
+            )
+        return raw.strip().upper()
+    return compiler.process(unit_arg, **kwargs).strip().strip("'\"").upper()
+
+
 @compiles(timestampdiff, "cockroachdb")
 def _compile_timestampdiff_cockroachdb(element, compiler, **kwargs):
     """Compile ``timestampdiff(unit, start, end)`` for the cockroachdb dialect.
@@ -141,11 +163,13 @@ def _compile_timestampdiff_cockroachdb(element, compiler, **kwargs):
     args = list(element.clauses)
     if len(args) != 3:
         raise ValueError(f"timestampdiff() expects 3 arguments (unit, start, end); got {len(args)}")
-    unit_token = compiler.process(args[0], **kwargs).strip().strip("'\"").upper()
+    unit_token = _resolve_timestampdiff_unit(args[0], compiler, **kwargs)
     if unit_token not in _TIMESTAMPDIFF_UNIT_FACTOR:
         raise ValueError(
             f"Unsupported timestampdiff() unit for cockroachdb dialect: {unit_token!r}. "
-            f"Supported units: {sorted(_TIMESTAMPDIFF_UNIT_FACTOR)}"
+            f"Supported units: {sorted(_TIMESTAMPDIFF_UNIT_FACTOR)}. "
+            "Pass the unit as a plain string, sqlalchemy.literal(unit), "
+            "or sqlalchemy.text(unit)."
         )
     start_expr = compiler.process(args[1], **kwargs)
     end_expr = compiler.process(args[2], **kwargs)

--- a/sqlalchemy_cockroachdb/stmt_compiler.py
+++ b/sqlalchemy_cockroachdb/stmt_compiler.py
@@ -127,7 +127,16 @@ _TIMESTAMPDIFF_UNIT_FACTOR = {
     "MINUTE": " / 60",
     "HOUR": " / 3600",
     "DAY": " / 86400",
+    "WEEK": " / 604800",
 }
+
+# Calendar-aware units are intentionally not implemented. MySQL's
+# ``TIMESTAMPDIFF(MONTH, ...)`` walks the calendar so that ``Feb 28 -> Mar 1``
+# is one month while ``Mar 1 -> Mar 30`` is zero months. That logic cannot be
+# derived from epoch arithmetic; a faithful implementation would need
+# ``EXTRACT(YEAR FROM AGE(end, start))`` plus month math. Listing them here
+# lets us emit a specific error rather than the generic "unsupported unit" one.
+_TIMESTAMPDIFF_CALENDAR_AWARE_UNITS = frozenset({"MONTH", "QUARTER", "YEAR"})
 
 
 def _resolve_timestampdiff_unit(unit_arg, compiler, **kwargs):
@@ -155,15 +164,39 @@ def _resolve_timestampdiff_unit(unit_arg, compiler, **kwargs):
 def _compile_timestampdiff_cockroachdb(element, compiler, **kwargs):
     """Compile ``timestampdiff(unit, start, end)`` for the cockroachdb dialect.
 
-    The result is cast to ``NUMERIC`` so callers may safely combine it with
-    integer or numeric divisors. CockroachDB rejects ``float / decimal``
-    arithmetic that PostgreSQL accepts, and ``EXTRACT(EPOCH FROM ...)``
-    returns a float on CockroachDB.
+    Output shape::
+
+        TRUNC(CAST(EXTRACT(EPOCH FROM (end - start)) AS NUMERIC) <factor>)
+
+    The ``TRUNC()`` wrap matches MySQL's ``TIMESTAMPDIFF`` semantics: the
+    result is the integer count of complete units between the two timestamps,
+    truncated toward zero. Without it, a 90-second diff at ``MINUTE`` would
+    return ``1.5`` on cockroachdb where MySQL returns ``1``.
+
+    The cast to ``NUMERIC`` (rather than to ``BIGINT``) is intentional. It
+    keeps the value integer-truncated like MySQL while still allowing
+    downstream divisors -- e.g. Apache Airflow's
+    ``timestampdiff(MICROSECOND, ...) / 1_000_000`` pattern -- to do
+    floating-point division on cockroachdb. Returning ``BIGINT`` would force
+    integer division on the divisor and silently lose sub-second precision.
+
+    Calendar-aware units (``MONTH``, ``QUARTER``, ``YEAR``) are intentionally
+    rejected with a specific error; see ``_TIMESTAMPDIFF_CALENDAR_AWARE_UNITS``
+    for the rationale.
     """
     args = list(element.clauses)
     if len(args) != 3:
         raise ValueError(f"timestampdiff() expects 3 arguments (unit, start, end); got {len(args)}")
     unit_token = _resolve_timestampdiff_unit(args[0], compiler, **kwargs)
+    if unit_token in _TIMESTAMPDIFF_CALENDAR_AWARE_UNITS:
+        raise ValueError(
+            f"timestampdiff() unit {unit_token!r} is not supported on the cockroachdb "
+            "dialect. Calendar-aware units (MONTH, QUARTER, YEAR) require calendar "
+            "walking (e.g. Feb 28 -> Mar 1 is 1 month) that cannot be derived from "
+            "epoch arithmetic alone, and are intentionally omitted. "
+            "If you need them, please open an issue at "
+            "https://github.com/cockroachdb/sqlalchemy-cockroachdb/issues."
+        )
     if unit_token not in _TIMESTAMPDIFF_UNIT_FACTOR:
         raise ValueError(
             f"Unsupported timestampdiff() unit for cockroachdb dialect: {unit_token!r}. "
@@ -175,4 +208,4 @@ def _compile_timestampdiff_cockroachdb(element, compiler, **kwargs):
     end_expr = compiler.process(args[2], **kwargs)
     epoch_diff = f"CAST(EXTRACT(EPOCH FROM ({end_expr} - {start_expr})) AS NUMERIC)"
     factor = _TIMESTAMPDIFF_UNIT_FACTOR[unit_token]
-    return f"({epoch_diff}{factor})" if factor else epoch_diff
+    return f"TRUNC({epoch_diff}{factor})"

--- a/sqlalchemy_cockroachdb/stmt_compiler.py
+++ b/sqlalchemy_cockroachdb/stmt_compiler.py
@@ -1,5 +1,7 @@
 from sqlalchemy.dialects.postgresql.base import PGCompiler
 from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.functions import GenericFunction
 
 # This is extracted from CockroachDB's `sql.y`. Add keywords here if *NEW* reserved keywords
 # are added to sql.y. DO NOT DELETE keywords here, even if they are deleted from sql.y:
@@ -100,3 +102,53 @@ class CockroachIdentifierPreparer(PGIdentifierPreparer):
 class CockroachCompiler(PGCompiler):
     def format_from_hint_text(self, sqltext, table, hint, iscrud):
         return f"{sqltext}@{hint}"
+
+
+class timestampdiff(GenericFunction):
+    """MySQL-style ``timestampdiff(unit, start, end)`` for cross-dialect SQL.
+
+    CockroachDB does not implement MySQL's ``timestampdiff()``. Applications
+    that target multiple database backends (notably Apache Airflow's ORM)
+    sometimes call ``func.timestampdiff(...)`` and rely on the database to
+    accept it. Registering this :class:`GenericFunction` lets the cockroachdb
+    statement compiler translate the call into a PostgreSQL-style
+    ``EXTRACT(EPOCH FROM (end - start))`` expression.
+    """
+
+    inherit_cache = True
+    name = "timestampdiff"
+
+
+_TIMESTAMPDIFF_UNIT_FACTOR = {
+    "MICROSECOND": " * 1000000",
+    "MILLISECOND": " * 1000",
+    "SECOND": "",
+    "MINUTE": " / 60",
+    "HOUR": " / 3600",
+    "DAY": " / 86400",
+}
+
+
+@compiles(timestampdiff, "cockroachdb")
+def _compile_timestampdiff_cockroachdb(element, compiler, **kwargs):
+    """Compile ``timestampdiff(unit, start, end)`` for the cockroachdb dialect.
+
+    The result is cast to ``NUMERIC`` so callers may safely combine it with
+    integer or numeric divisors. CockroachDB rejects ``float / decimal``
+    arithmetic that PostgreSQL accepts, and ``EXTRACT(EPOCH FROM ...)``
+    returns a float on CockroachDB.
+    """
+    args = list(element.clauses)
+    if len(args) != 3:
+        raise ValueError(f"timestampdiff() expects 3 arguments (unit, start, end); got {len(args)}")
+    unit_token = compiler.process(args[0], **kwargs).strip().strip("'\"").upper()
+    if unit_token not in _TIMESTAMPDIFF_UNIT_FACTOR:
+        raise ValueError(
+            f"Unsupported timestampdiff() unit for cockroachdb dialect: {unit_token!r}. "
+            f"Supported units: {sorted(_TIMESTAMPDIFF_UNIT_FACTOR)}"
+        )
+    start_expr = compiler.process(args[1], **kwargs)
+    end_expr = compiler.process(args[2], **kwargs)
+    epoch_diff = f"CAST(EXTRACT(EPOCH FROM ({end_expr} - {start_expr})) AS NUMERIC)"
+    factor = _TIMESTAMPDIFF_UNIT_FACTOR[unit_token]
+    return f"({epoch_diff}{factor})" if factor else epoch_diff

--- a/test/test_timestampdiff.py
+++ b/test/test_timestampdiff.py
@@ -4,6 +4,7 @@ from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import TIMESTAMP
+from sqlalchemy import literal
 from sqlalchemy import select
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
@@ -25,8 +26,9 @@ def _events_table():
     )
 
 
-def _compile(stmt, dialect):
-    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+def _compile(stmt, dialect, literal_binds=True):
+    kwargs = {"literal_binds": True} if literal_binds else {}
+    return str(stmt.compile(dialect=dialect, compile_kwargs=kwargs))
 
 
 class TimestampdiffCompilerTest(fixtures.TestBase):
@@ -89,3 +91,34 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         sql = _compile(select(expr), postgresql_dialect())
         assert "EXTRACT" not in sql
         assert "timestampdiff" in sql.lower()
+
+    def test_plain_string_unit_accepted(self):
+        """Plain Python string unit must resolve to a real unit, not a bound placeholder.
+
+        Compiles WITHOUT literal_binds to mirror how Airflow's ORM actually executes
+        statements — BindParameters render as ``$1`` / ``%(...)s`` unless we extract
+        the value at compile time.
+        """
+        expr = func.timestampdiff("MICROSECOND", self.events.c.start_date, self.events.c.end_date)
+        sql = _compile(select(expr), self.dialect, literal_binds=False)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "* 1000000" in sql
+        assert "%(" not in sql
+        assert "$1" not in sql
+
+    def test_literal_unit_accepted(self):
+        """``literal('SECOND')`` should resolve via BindParameter value, not a placeholder."""
+        expr = func.timestampdiff(
+            literal("SECOND"), self.events.c.start_date, self.events.c.end_date
+        )
+        sql = _compile(select(expr), self.dialect, literal_binds=False)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "AS NUMERIC" in sql
+        assert "%(" not in sql
+        assert "$1" not in sql
+
+    def test_non_string_bind_value_rejected_clearly(self):
+        """A BindParameter whose value isn't a string must produce a clear error."""
+        expr = func.timestampdiff(123, self.events.c.start_date, self.events.c.end_date)
+        with pytest.raises(ValueError, match="must be a string"):
+            _compile(select(expr), self.dialect, literal_binds=False)

--- a/test/test_timestampdiff.py
+++ b/test/test_timestampdiff.py
@@ -1,0 +1,91 @@
+import pytest
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import Table
+from sqlalchemy import TIMESTAMP
+from sqlalchemy import select
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
+from sqlalchemy.sql import func
+from sqlalchemy.testing import fixtures
+
+from sqlalchemy_cockroachdb.psycopg2 import CockroachDBDialect_psycopg2
+from sqlalchemy_cockroachdb.stmt_compiler import timestampdiff  # noqa: F401  registers compiler
+
+
+def _events_table():
+    metadata = MetaData()
+    return Table(
+        "events",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("start_date", TIMESTAMP),
+        Column("end_date", TIMESTAMP),
+    )
+
+
+def _compile(stmt, dialect):
+    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+class TimestampdiffCompilerTest(fixtures.TestBase):
+    """Compile-only tests: no live database connection required."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.dialect = CockroachDBDialect_psycopg2()
+        self.events = _events_table()
+
+    @pytest.mark.parametrize(
+        "unit,expected_suffix",
+        [
+            ("MICROSECOND", "* 1000000"),
+            ("MILLISECOND", "* 1000"),
+            ("MINUTE", "/ 60"),
+            ("HOUR", "/ 3600"),
+            ("DAY", "/ 86400"),
+        ],
+    )
+    def test_compiles_with_arithmetic_suffix(self, unit, expected_suffix):
+        expr = func.timestampdiff(text(unit), self.events.c.start_date, self.events.c.end_date)
+        sql = _compile(select(expr), self.dialect)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "AS NUMERIC" in sql
+        assert expected_suffix in sql
+
+    def test_seconds_has_no_arithmetic_suffix(self):
+        expr = func.timestampdiff(text("SECOND"), self.events.c.start_date, self.events.c.end_date)
+        sql = _compile(select(expr), self.dialect)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "AS NUMERIC" in sql
+        after_cast = sql.split("AS NUMERIC", 1)[1]
+        assert " * " not in after_cast
+        assert " / " not in after_cast
+
+    def test_lowercase_unit_accepted(self):
+        expr = func.timestampdiff(
+            text("microsecond"), self.events.c.start_date, self.events.c.end_date
+        )
+        sql = _compile(select(expr), self.dialect)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "* 1000000" in sql
+
+    def test_unknown_unit_rejected(self):
+        expr = func.timestampdiff(
+            text("FORTNIGHT"), self.events.c.start_date, self.events.c.end_date
+        )
+        with pytest.raises(ValueError, match="Unsupported timestampdiff"):
+            _compile(select(expr), self.dialect)
+
+    def test_wrong_arity_rejected(self):
+        expr = func.timestampdiff(text("SECOND"), self.events.c.start_date)
+        with pytest.raises(ValueError, match="3 arguments"):
+            _compile(select(expr), self.dialect)
+
+    def test_postgresql_dialect_unaffected(self):
+        """The cockroachdb compiler hook must not change rendering for other dialects."""
+        expr = func.timestampdiff(text("SECOND"), self.events.c.start_date, self.events.c.end_date)
+        sql = _compile(select(expr), postgresql_dialect())
+        assert "EXTRACT" not in sql
+        assert "timestampdiff" in sql.lower()

--- a/test/test_timestampdiff.py
+++ b/test/test_timestampdiff.py
@@ -47,6 +47,7 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
             ("MINUTE", "/ 60"),
             ("HOUR", "/ 3600"),
             ("DAY", "/ 86400"),
+            ("WEEK", "/ 604800"),
         ],
     )
     def test_compiles_with_arithmetic_suffix(self, unit, expected_suffix):
@@ -55,15 +56,35 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         assert "EXTRACT(EPOCH FROM" in sql
         assert "AS NUMERIC" in sql
         assert expected_suffix in sql
+        assert "TRUNC(" in sql
 
     def test_seconds_has_no_arithmetic_suffix(self):
+        """SECOND has no factor token but is still wrapped in TRUNC for MySQL parity."""
         expr = func.timestampdiff(text("SECOND"), self.events.c.start_date, self.events.c.end_date)
         sql = _compile(select(expr), self.dialect)
         assert "EXTRACT(EPOCH FROM" in sql
         assert "AS NUMERIC" in sql
+        assert "TRUNC(" in sql
         after_cast = sql.split("AS NUMERIC", 1)[1]
         assert " * " not in after_cast
         assert " / " not in after_cast
+
+    def test_truncates_to_match_mysql_semantics(self):
+        """Regression for #301 review: MySQL TIMESTAMPDIFF returns BIGINT (truncated
+        toward zero), so a 90-second diff at MINUTE returns 1, not 1.5. The cockroachdb
+        compilation must wrap the arithmetic in TRUNC() so the *value* matches MySQL,
+        even though we deliberately keep the NUMERIC return type for downstream
+        divisor compatibility (see compiler docstring).
+        """
+        expr = func.timestampdiff(text("MINUTE"), self.events.c.start_date, self.events.c.end_date)
+        sql = _compile(select(expr), self.dialect)
+        # TRUNC must wrap the divided expression, not just the EPOCH cast.
+        assert "TRUNC(" in sql
+        trunc_idx = sql.index("TRUNC(")
+        factor_idx = sql.index("/ 60")
+        assert trunc_idx < factor_idx, f"TRUNC should wrap the division; got SQL: {sql!r}"
+        # The closing paren of TRUNC must come after the factor: "/ 60)" must appear.
+        assert "/ 60)" in sql
 
     def test_lowercase_unit_accepted(self):
         expr = func.timestampdiff(
@@ -72,12 +93,23 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         sql = _compile(select(expr), self.dialect)
         assert "EXTRACT(EPOCH FROM" in sql
         assert "* 1000000" in sql
+        assert "TRUNC(" in sql
 
     def test_unknown_unit_rejected(self):
         expr = func.timestampdiff(
             text("FORTNIGHT"), self.events.c.start_date, self.events.c.end_date
         )
         with pytest.raises(ValueError, match="Unsupported timestampdiff"):
+            _compile(select(expr), self.dialect)
+
+    @pytest.mark.parametrize("unit", ["MONTH", "QUARTER", "YEAR", "month", "Year"])
+    def test_calendar_aware_units_rejected_with_explanation(self, unit):
+        """MONTH/QUARTER/YEAR must be rejected with a specific error explaining
+        why they're intentionally omitted (calendar-walking vs epoch arithmetic),
+        not the generic 'unsupported unit' error.
+        """
+        expr = func.timestampdiff(text(unit), self.events.c.start_date, self.events.c.end_date)
+        with pytest.raises(ValueError, match="Calendar-aware units"):
             _compile(select(expr), self.dialect)
 
     def test_wrong_arity_rejected(self):
@@ -103,6 +135,7 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         sql = _compile(select(expr), self.dialect, literal_binds=False)
         assert "EXTRACT(EPOCH FROM" in sql
         assert "* 1000000" in sql
+        assert "TRUNC(" in sql
         assert "%(" not in sql
         assert "$1" not in sql
 
@@ -114,6 +147,7 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         sql = _compile(select(expr), self.dialect, literal_binds=False)
         assert "EXTRACT(EPOCH FROM" in sql
         assert "AS NUMERIC" in sql
+        assert "TRUNC(" in sql
         assert "%(" not in sql
         assert "$1" not in sql
 

--- a/test/test_timestampdiff.py
+++ b/test/test_timestampdiff.py
@@ -1,14 +1,19 @@
+from datetime import datetime
+
 import pytest
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import Table
 from sqlalchemy import TIMESTAMP
+from sqlalchemy import bindparam
 from sqlalchemy import literal
+from sqlalchemy import null
 from sqlalchemy import select
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 from sqlalchemy.sql import func
+from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 
 from sqlalchemy_cockroachdb.psycopg2 import CockroachDBDialect_psycopg2
@@ -70,21 +75,17 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         assert " / " not in after_cast
 
     def test_truncates_to_match_mysql_semantics(self):
-        """Regression for #301 review: MySQL TIMESTAMPDIFF returns BIGINT (truncated
-        toward zero), so a 90-second diff at MINUTE returns 1, not 1.5. The cockroachdb
-        compilation must wrap the arithmetic in TRUNC() so the *value* matches MySQL,
-        even though we deliberately keep the NUMERIC return type for downstream
-        divisor compatibility (see compiler docstring).
+        """A 90-second diff at MINUTE must compile to a TRUNC()-wrapped expression
+        so the value matches MySQL's integer-truncation semantics. See compiler
+        docstring for the full rationale.
         """
         expr = func.timestampdiff(text("MINUTE"), self.events.c.start_date, self.events.c.end_date)
         sql = _compile(select(expr), self.dialect)
-        # TRUNC must wrap the divided expression, not just the EPOCH cast.
-        assert "TRUNC(" in sql
-        trunc_idx = sql.index("TRUNC(")
-        factor_idx = sql.index("/ 60")
-        assert trunc_idx < factor_idx, f"TRUNC should wrap the division; got SQL: {sql!r}"
-        # The closing paren of TRUNC must come after the factor: "/ 60)" must appear.
-        assert "/ 60)" in sql
+        # Single anchored assertion: cast closes, factor applies, TRUNC closes.
+        # A regression that emitted ``TRUNC(CAST(...)) / 60`` would still satisfy
+        # weaker checks like ``"/ 60)" in sql``; the anchored fragment below
+        # rejects that shape.
+        assert "AS NUMERIC) / 60)" in sql, f"TRUNC must wrap the division; got SQL: {sql!r}"
 
     def test_lowercase_unit_accepted(self):
         expr = func.timestampdiff(
@@ -122,7 +123,9 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         expr = func.timestampdiff(text("SECOND"), self.events.c.start_date, self.events.c.end_date)
         sql = _compile(select(expr), postgresql_dialect())
         assert "EXTRACT" not in sql
-        assert "timestampdiff" in sql.lower()
+        # Anchor on the call form rather than substring; "timestampdifference" or
+        # similar names would otherwise pass.
+        assert "timestampdiff(" in sql.lower()
 
     def test_plain_string_unit_accepted(self):
         """Plain Python string unit must resolve to a real unit, not a bound placeholder.
@@ -156,3 +159,117 @@ class TimestampdiffCompilerTest(fixtures.TestBase):
         expr = func.timestampdiff(123, self.events.c.start_date, self.events.c.end_date)
         with pytest.raises(ValueError, match="must be a string"):
             _compile(select(expr), self.dialect, literal_binds=False)
+
+    def test_bindparam_unit_accepted(self):
+        """An explicit ``bindparam(name, value)`` should resolve via the BindParameter
+        path, the same as plain strings and ``literal()``.
+        """
+        expr = func.timestampdiff(
+            bindparam("u", "SECOND"),
+            self.events.c.start_date,
+            self.events.c.end_date,
+        )
+        sql = _compile(select(expr), self.dialect, literal_binds=False)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "TRUNC(" in sql
+        assert "%(" not in sql
+        assert "$1" not in sql
+
+    def test_whitespace_in_text_unit_stripped(self):
+        """``text(' SECOND ')`` should resolve to ``SECOND`` after .strip()."""
+        expr = func.timestampdiff(
+            text(" SECOND "), self.events.c.start_date, self.events.c.end_date
+        )
+        sql = _compile(select(expr), self.dialect)
+        assert "EXTRACT(EPOCH FROM" in sql
+        assert "TRUNC(" in sql
+
+    def test_null_unit_rejected(self):
+        """``null()`` as the unit argument must produce a clear error rather than
+        silently rendering ``NULL`` as a unit token.
+        """
+        expr = func.timestampdiff(null(), self.events.c.start_date, self.events.c.end_date)
+        with pytest.raises(ValueError, match="Unsupported timestampdiff"):
+            _compile(select(expr), self.dialect)
+
+
+class TimestampdiffBackendTest(fixtures.TablesTest):
+    """Live-database tests against CockroachDB.
+
+    Compile-only tests above verify the SQL string shape; these tests verify
+    the *value* semantics by executing the compiled queries against a live
+    cockroachdb instance. Without these, a future change that altered
+    compilation (e.g. swapping ``TRUNC()`` for ``FLOOR()``) could pass every
+    compile-time test while diverging from MySQL's actual behavior.
+    """
+
+    __backend__ = True
+    __only_on__ = "cockroachdb"
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "events_for_timestampdiff",
+            metadata,
+            Column("id", Integer, primary_key=True, autoincrement=False),
+            Column("start_date", TIMESTAMP),
+            Column("end_date", TIMESTAMP),
+        )
+
+    @classmethod
+    def insert_data(cls, connection):
+        connection.execute(
+            cls.tables.events_for_timestampdiff.insert(),
+            [
+                # 90 seconds positive: MySQL TIMESTAMPDIFF(MINUTE) = 1, not 1.5.
+                dict(
+                    id=1,
+                    start_date=datetime(2026, 1, 1, 0, 0, 0),
+                    end_date=datetime(2026, 1, 1, 0, 1, 30),
+                ),
+                # 90 seconds negative (start > end): MySQL = -1 because TIMESTAMPDIFF
+                # truncates toward zero. A FLOOR()-based implementation would return
+                # -2 here while still passing every positive-diff test.
+                dict(
+                    id=2,
+                    start_date=datetime(2026, 1, 1, 0, 1, 30),
+                    end_date=datetime(2026, 1, 1, 0, 0, 0),
+                ),
+                # 1.5 seconds positive: feeds the Airflow division-pattern test.
+                dict(
+                    id=3,
+                    start_date=datetime(2026, 1, 1, 0, 0, 0),
+                    end_date=datetime(2026, 1, 1, 0, 0, 1, 500000),
+                ),
+            ],
+        )
+
+    def test_minute_diff_truncates_positive(self, connection):
+        events = self.tables.events_for_timestampdiff
+        expr = func.timestampdiff(text("MINUTE"), events.c.start_date, events.c.end_date)
+        result = connection.execute(select(expr).where(events.c.id == 1)).scalar()
+        eq_(int(result), 1)
+
+    def test_minute_diff_truncates_negative_toward_zero(self, connection):
+        """Pins TRUNC-toward-zero (not FLOOR). For a -90 second diff at MINUTE:
+        TRUNC(-1.5) = -1, FLOOR(-1.5) = -2. MySQL returns -1.
+        """
+        events = self.tables.events_for_timestampdiff
+        expr = func.timestampdiff(text("MINUTE"), events.c.start_date, events.c.end_date)
+        result = connection.execute(select(expr).where(events.c.id == 2)).scalar()
+        eq_(int(result), -1)
+
+    def test_airflow_microsecond_division_pattern(self, connection):
+        """Airflow's exact pattern: timestampdiff(MICROSECOND, start, end) / 1_000_000.
+
+        Confirms the NUMERIC return type does NOT trigger cockroachdb's
+        ``unsupported binary operator: <float> / <decimal>`` rejection that
+        an unwrapped ``EXTRACT(EPOCH FROM ...)`` (a float) would. The cast
+        to NUMERIC inside the compilation is what makes this work.
+        """
+        events = self.tables.events_for_timestampdiff
+        microsec = func.timestampdiff(text("MICROSECOND"), events.c.start_date, events.c.end_date)
+        seconds = microsec / 1_000_000
+        result = connection.execute(select(seconds).where(events.c.id == 3)).scalar()
+        # 1.5s diff -> 1500000 microseconds (TRUNCated) / 1_000_000 -> 1.5
+        eq_(float(result), 1.5)


### PR DESCRIPTION
## Summary

Cross-dialect ORMs (notably [Apache Airflow](https://github.com/apache/airflow)) fall back to MySQL-style `func.timestampdiff(unit, start, end)` for any non-PostgreSQL backend. CockroachDB does not implement `timestampdiff()`, so applications using `cockroachdb://` URIs against such ORMs hit `unknown function: timestampdiff()` errors at runtime.

This PR registers a `timestampdiff` `GenericFunction` and a `@compiles(timestampdiff, "cockroachdb")` hook that translates the call into a PostgreSQL-style expression:

```sql
TRUNC(CAST(EXTRACT(EPOCH FROM (end - start)) AS NUMERIC) <unit factor>)
```

The `TRUNC()` wrap matches MySQL's `TIMESTAMPDIFF` semantics — the result is the integer count of complete units between the two timestamps, truncated toward zero. Without it, a 90-second diff at `MINUTE` would return `1.5` on CockroachDB where MySQL returns `1`.

The `CAST(... AS NUMERIC)` is intentional (rather than `BIGINT`). It keeps the value integer-truncated like MySQL while still allowing downstream divisors — e.g. Apache Airflow's `timestampdiff(MICROSECOND, ...) / 1_000_000` pattern — to do floating-point division on CockroachDB. Returning `BIGINT` would force integer division on the divisor and silently lose sub-second precision. It also avoids the `float / decimal` arithmetic errors that CockroachDB rejects but PostgreSQL accepts.

Other dialects are unaffected.

### Supported units

| Unit        | Compiled expression                  |
|-------------|--------------------------------------|
| MICROSECOND | `TRUNC(epoch_diff * 1000000)`        |
| MILLISECOND | `TRUNC(epoch_diff * 1000)`           |
| SECOND      | `TRUNC(epoch_diff)`                  |
| MINUTE      | `TRUNC(epoch_diff / 60)`             |
| HOUR        | `TRUNC(epoch_diff / 3600)`           |
| DAY         | `TRUNC(epoch_diff / 86400)`          |
| WEEK        | `TRUNC(epoch_diff / 604800)`         |

…where `epoch_diff` is `CAST(EXTRACT(EPOCH FROM (end - start)) AS NUMERIC)`.

### Intentionally unsupported

Calendar-aware units (`MONTH`, `QUARTER`, `YEAR`) are explicitly rejected with a specific error message at compile time. They require calendar walking (e.g. Feb 28 → Mar 1 is 1 month, while Mar 1 → Mar 30 is 0 months) that cannot be derived from epoch arithmetic alone. A faithful implementation would need `EXTRACT(YEAR FROM AGE(end, start))` plus month math; happy to add it on a concrete user need.

Unknown units, wrong arity, and non-string `BindParameter` values also raise `ValueError` at compile time so the failure mode is loud and early.

### Motivation

Validated against an Apache Airflow 3.x metadata-backend integration PoC against CockroachDB v25.4. Airflow's `airflow-core/src/airflow/models/taskinstance.py` calls `func.timestampdiff(text("MICROSECOND"), start, end) / 1_000_000` for any non-postgres/sqlite dialect; on `cockroachdb://` this previously failed with `unknown function: timestampdiff()`. After this change the same expression compiles to:

```sql
TRUNC(CAST(EXTRACT(EPOCH FROM (end - start)) AS NUMERIC) * 1000000) / CAST(1000000 AS NUMERIC)
```

…which CockroachDB accepts and which evaluates to the same integer microsecond count MySQL would return. Airflow itself still needs a small dialect-name addition upstream, but this PR removes the need for any CockroachDB-specific shim there — the dialect handles itself.

### Argument forms accepted for the unit

The unit must be known at compile time. The compiler accepts:

- plain Python string: `func.timestampdiff("SECOND", a, b)`
- `sqlalchemy.literal(unit)` — `BindParameter`'s `.value` is read directly so it doesn't render as `$1` / `%(...)s`
- `sqlalchemy.text(unit)` / `sqlalchemy.literal_column(unit)` — rendered as a literal SQL token

Runtime-bound or column-reference units are rejected with a clear `ValueError`.

## Test plan

- Added `test/test_timestampdiff.py` — compile-only assertions covering:
  - all supported units (parametrized)
  - lowercase unit tokens
  - `TRUNC()` wraps the full divided expression (MySQL-parity regression)
  - `SECOND` produces no arithmetic suffix but still wraps in `TRUNC()`
  - unknown units rejected
  - calendar-aware units (`MONTH`/`QUARTER`/`YEAR`, mixed case) rejected with a specific error
  - wrong arity rejected
  - plain-string and `literal()` unit args don't render as bound placeholders
  - non-string `BindParameter` values rejected with a clear error
  - postgresql dialect rendering is unchanged
- Existing test suite collection clean (1522 tests).
- `flake8 --extend-ignore F405 sqlalchemy_cockroachdb test` passes.
- `black --line-length 100` applied to modified files.
- Compile-output smoke test against Airflow's exact call shape produces the expected SQL.
- CI: integration runs against CockroachDB v24.3 / v25.2 / v25.4 / v26.1 with psycopg2, asyncpg, psycopg.

## Notes

- `timestampdiff` is registered as a SQLAlchemy `GenericFunction` (global), but the `@compiles` hook is dialect-scoped to `"cockroachdb"`. Default rendering for other dialects is unchanged (verified by `test_postgresql_dialect_unaffected`).
- The hook lives in `stmt_compiler.py` alongside the existing `CockroachCompiler` and is loaded transitively when any cockroachdb dialect URL is used.
- `CHANGES.md` updated under unreleased 2.0.4.
