### PR TITLE
Prepare v2.0.4 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # Version 2.0.4
-Unreleased
+April 23, 2026
 
 - Fix reflection of CHAR columns (#275)
 - Fix reflection of TIMESTAMPTZ columns (#276), thanks to @nvachhar

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Version 2.0.5
+Unreleased
+
+
 # Version 2.0.4
 April 23, 2026
 

--- a/sqlalchemy_cockroachdb/__init__.py
+++ b/sqlalchemy_cockroachdb/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy.dialects import registry as _registry
 from .transaction import run_transaction  # noqa
 
-__version__ = "2.0.4.dev0"
+__version__ = "2.0.4"
 
 _registry.register(
     "cockroachdb.psycopg2",

--- a/sqlalchemy_cockroachdb/__init__.py
+++ b/sqlalchemy_cockroachdb/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy.dialects import registry as _registry
 from .transaction import run_transaction  # noqa
 
-__version__ = "2.0.4"
+__version__ = "2.0.5.dev0"
 
 _registry.register(
     "cockroachdb.psycopg2",


### PR DESCRIPTION
## Summary
- Prepare v2.0.4 release (set release date in CHANGES.md, drop `.dev0` suffix from version)
- Begin v2.0.5 development (add Unreleased section to CHANGES.md, bump version to `2.0.5.dev0`)

After merge, tag the release commit as `v2.0.4` and push the tag.

## Test plan
- [ ] CI passes