### PR TITLE
Support SQLAlchemy row security DDL and reflection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Version 2.0.5
 Unreleased
 
+- Add SQLAlchemy 2.1 row security DDL and reflection support.
 
 # Version 2.0.4
 April 23, 2026

--- a/README.md
+++ b/README.md
@@ -89,19 +89,6 @@ To connect using psycopg for async operation, see
 [README.psycopg.md](README.psycopg.md)
 
 
-## Row level security
-
-SQLAlchemy 2.1 policy DDL and reflection work through the dialect's PostgreSQL
-inheritance and CockroachDB's `pg_catalog` compatibility. Row level security
-requires CockroachDB 25.2 or newer.
-
-Policy declaration, DDL execution, and inspection therefore use the same
-SQLAlchemy API on PostgreSQL and CockroachDB. Database behavior still differs.
-CockroachDB does not support subqueries in policy expressions, and applications
-should review its documented `ON CONFLICT DO NOTHING` policy behavior before
-using that statement for security-sensitive inserts. CockroachDB also does not
-accept PostgreSQL's `CURRENT_ROLE` policy target.
-
 ## Changelog
 
 See [CHANGES.md](CHANGES.md)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Use `pip` to install the latest release of this dialect.
 pip install sqlalchemy-cockroachdb
 ```
 
-NOTE: This version of the dialect requires SQLAlchemy 2.0.x. To work with
+NOTE: This version of the dialect requires SQLAlchemy 2.1.x. To work with
 earlier versions of SQLAlchemy you'll need to install an earlier version of this
 dialect.
 
@@ -88,6 +88,19 @@ engine = create_engine('cockroachdb+psycopg://root@localhost:26257/defaultdb')
 To connect using psycopg for async operation, see
 [README.psycopg.md](README.psycopg.md)
 
+
+## Row level security
+
+SQLAlchemy 2.1 policy DDL and reflection work through the dialect's PostgreSQL
+inheritance and CockroachDB's `pg_catalog` compatibility. Row level security
+requires CockroachDB 25.2 or newer.
+
+Policy declaration, DDL execution, and inspection therefore use the same
+SQLAlchemy API on PostgreSQL and CockroachDB. Database behavior still differs.
+CockroachDB does not support subqueries in policy expressions, and applications
+should review its documented `ON CONFLICT DO NOTHING` policy behavior before
+using that statement for security-sensitive inserts. CockroachDB also does not
+accept PostgreSQL's `CURRENT_ROLE` policy target.
 
 ## Changelog
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     },
     packages=find_packages(include=["sqlalchemy_cockroachdb"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy>=2.0.47,<2.1"],
+    install_requires=["SQLAlchemy>=2.1.0b4,<2.2"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     },
     packages=find_packages(include=["sqlalchemy_cockroachdb"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy>=2.1.0b4,<2.2"],
+    install_requires=["SQLAlchemy>=2.1.0b3,<2.2"],
     zip_safe=False,
     entry_points={
         "sqlalchemy.dialects": [

--- a/sqlalchemy_cockroachdb/ddl_compiler.py
+++ b/sqlalchemy_cockroachdb/ddl_compiler.py
@@ -14,3 +14,8 @@ class CockroachDDLCompiler(PGDDLCompiler):
         return "AS (%s) STORED" % self.sql_compiler.process(
             generated.sqltext, include_table=False, literal_binds=True
         )
+
+    def _format_policy_role(self, role):
+        if role == "CURRENT_ROLE":
+            raise exc.CompileError("CockroachDB row security does not support CURRENT_ROLE")
+        return super()._format_policy_role(role)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -12,4 +12,4 @@ more-itertools
 psycopg
 psycopg2
 pytest
-sqlalchemy>=2.1.0b4,<2.2
+sqlalchemy @ git+https://github.com/Pedrexus/sqlalchemy.git@1bbe0d64d6017b346a5e6f7bf784ba7a3294662f

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -12,4 +12,4 @@ more-itertools
 psycopg
 psycopg2
 pytest
-sqlalchemy>=2.0.47,<2.1
+sqlalchemy>=2.1.0b4,<2.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ exceptiongroup==1.3.1
     # via pytest
 futures==3.0.5
     # via -r test-requirements.in
-greenlet==3.5.0
-    # via sqlalchemy
 iniconfig==2.3.0
     # via pytest
 mako==1.3.12
@@ -32,7 +30,7 @@ pygments==2.20.0
     # via pytest
 pytest==9.0.3
     # via -r test-requirements.in
-sqlalchemy==2.0.49
+sqlalchemy @ git+https://github.com/Pedrexus/sqlalchemy.git@1bbe0d64d6017b346a5e6f7bf784ba7a3294662f
     # via
     #   -r test-requirements.in
     #   alembic

--- a/test/test_row_security.py
+++ b/test/test_row_security.py
@@ -18,26 +18,6 @@ from sqlalchemy.testing.assertions import expect_raises_message
 class RowSecurityCompileTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "cockroachdb"
 
-    def test_inherits_postgresql_policy_compiler(self):
-        table = Table(
-            "item",
-            MetaData(),
-            Column("owner_id", Integer),
-            schema="app",
-        )
-        policy = Policy(
-            "read",
-            table,
-            command="SELECT",
-            using=table.c.owner_id == 7,
-        )
-
-        self.assert_compile(
-            CreatePolicy(policy),
-            "CREATE POLICY read ON app.item FOR SELECT TO PUBLIC " "USING (owner_id = 7)",
-            literal_binds=True,
-        )
-
     def test_rejects_unsupported_current_role(self):
         table = Table("item", MetaData(), Column("owner_id", Integer))
         policy = Policy("read", table, roles=("CURRENT_ROLE",))

--- a/test/test_row_security.py
+++ b/test/test_row_security.py
@@ -1,0 +1,97 @@
+from sqlalchemy import Column
+from sqlalchemy import exc
+from sqlalchemy import inspect
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import Table
+from sqlalchemy import testing
+from sqlalchemy.dialects.postgresql import CreatePolicy
+from sqlalchemy.dialects.postgresql import EnableRowLevelSecurity
+from sqlalchemy.dialects.postgresql import ForceRowLevelSecurity
+from sqlalchemy.dialects.postgresql import Policy
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.assertions import AssertsCompiledSQL
+from sqlalchemy.testing.assertions import eq_
+from sqlalchemy.testing.assertions import expect_raises_message
+
+
+class RowSecurityCompileTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = "cockroachdb"
+
+    def test_inherits_postgresql_policy_compiler(self):
+        table = Table(
+            "item",
+            MetaData(),
+            Column("owner_id", Integer),
+            schema="app",
+        )
+        policy = Policy(
+            "read",
+            table,
+            command="SELECT",
+            using=table.c.owner_id == 7,
+        )
+
+        self.assert_compile(
+            CreatePolicy(policy),
+            "CREATE POLICY read ON app.item FOR SELECT TO PUBLIC " "USING (owner_id = 7)",
+            literal_binds=True,
+        )
+
+    def test_rejects_unsupported_current_role(self):
+        table = Table("item", MetaData(), Column("owner_id", Integer))
+        policy = Policy("read", table, roles=("CURRENT_ROLE",))
+
+        with expect_raises_message(
+            exc.CompileError,
+            "CockroachDB row security does not support CURRENT_ROLE",
+        ):
+            self.assert_compile(CreatePolicy(policy), "")
+
+
+class RowSecurityReflectionTest(fixtures.TestBase):
+    __only_on__ = "cockroachdb"
+    __requires__ = ("sync_driver",)
+
+    @testing.provide_metadata
+    def test_postgresql_compatible_reflection(self):
+        table = Table(
+            "row_security_reflection",
+            self.metadata,
+            Column("id", Integer, primary_key=True),
+            Column("owner_id", Integer),
+        )
+        with testing.db.begin() as connection:
+            table.create(connection)
+            connection.execute(EnableRowLevelSecurity(table))
+            connection.execute(ForceRowLevelSecurity(table))
+            connection.execute(
+                CreatePolicy(
+                    Policy(
+                        "read",
+                        table,
+                        command="SELECT",
+                        using=table.c.owner_id == 7,
+                    )
+                )
+            )
+
+            state = inspect(connection).get_row_security(table.name)
+
+        eq_(
+            state,
+            {
+                "enabled": True,
+                "forced": True,
+                "policies": [
+                    {
+                        "name": "read",
+                        "command": "SELECT",
+                        "roles": ["public"],
+                        "using": "owner_id = 7:::INT8",
+                        "check": None,
+                        "permissive": True,
+                    }
+                ],
+            },
+        )


### PR DESCRIPTION
## Summary

This prepares the dialect for SQLAlchemy 2.1 row security DDL and reflection.

CockroachDB can inherit the PostgreSQL policy compiler and catalog reflection. The only compiler difference is that CockroachDB does not accept PostgreSQL's `CURRENT_ROLE` policy target, so the dialect raises a compile error before sending unsupported SQL.

The focused tests cover that incompatibility and live policy reflection on CockroachDB 26.2.

## Dependency

This is a stacked draft while [SQLAlchemy issue 13517](https://github.com/sqlalchemy/sqlalchemy/issues/13517) waits for maintainer approval. The test requirements temporarily pin the exact public SQLAlchemy feature commit. That pin and the beta floor should be replaced by the first official SQLAlchemy release containing the row security API before this PR is ready to merge.

## Verification

- Python 3.10 tox environment
- CockroachDB 26.2 single node
- Two focused row security tests passed
- Repository lint tox environment passed
